### PR TITLE
Added Zones in VM config

### DIFF
--- a/Lab Templates/Lab Template -  NetSec Demo lab/AzNetSecdeploy.json
+++ b/Lab Templates/Lab Template -  NetSec Demo lab/AzNetSecdeploy.json
@@ -1658,6 +1658,9 @@
       "dependsOn": [
         "[concat('Microsoft.Network/networkInterfaces/', variables('NIC-Name1'))]"
       ],
+      "zones": [
+        "1"
+      ],
       "properties": {
         "hardwareProfile": {
           "vmSize": "Standard_B2s"
@@ -1708,6 +1711,9 @@
         "publisher": "kali-linux",
         "product": "kali-linux"
       },
+      "zones": [
+        "1"
+      ],
       "properties": {
         "hardwareProfile": {
           "vmSize": "Standard_B2s"
@@ -1748,6 +1754,9 @@
       "location": "[resourceGroup().location]",
       "dependsOn": [
         "[concat('Microsoft.Network/networkInterfaces/', variables('NIC-Name3'))]"
+      ],
+      "zones": [
+        "1"
       ],
       "properties": {
         "hardwareProfile": {

--- a/Lab Templates/Lab Template - WAF Attack Testing Lab/AzNetSecdeploy_Juice-Shop_AZFW-Rules_Updated.json
+++ b/Lab Templates/Lab Template - WAF Attack Testing Lab/AzNetSecdeploy_Juice-Shop_AZFW-Rules_Updated.json
@@ -1672,6 +1672,9 @@
       "dependsOn": [
         "[concat('Microsoft.Network/networkInterfaces/', variables('NIC-Name1'))]"
       ],
+      "zones": [
+        "1"
+      ],
       "properties": {
         "hardwareProfile": {
           "vmSize": "Standard_B2s"
@@ -1722,6 +1725,9 @@
         "publisher": "kali-linux",
         "product": "kali-linux"
       },
+      "zones": [
+        "1"
+      ],
       "properties": {
         "hardwareProfile": {
           "vmSize": "Standard_B2s"
@@ -1762,6 +1768,9 @@
       "location": "[resourceGroup().location]",
       "dependsOn": [
         "[concat('Microsoft.Network/networkInterfaces/', variables('NIC-Name3'))]"
+      ],
+      "zones": [
+        "1"
       ],
       "properties": {
         "hardwareProfile": {


### PR DESCRIPTION
ARM Deployment issues from Azure stating incorrect size in region or zone, added the zones in VM config and Validation passed with no errors, added configuration in both lab templates for each Azure VM

      "zones": [
        "1"
      ],


{"code":"MultipleErrorsOccurred","details":[{"code":"InvalidTemplateDeployment","message":"The template deployment failed with error: 'The resource with id: '/subscriptions/xxxx/resourceGroups/rgNetSecLab/providers/Microsoft.Compute/virtualMachines/VM-Win10' failed validation with message: 'The requested size for resource '/subscriptions/xxxx/resourceGroups/rgNetSecLab/providers/Microsoft.Compute/virtualMachines/VM-Win10' is currently not available in location 'eastus2' zones '' for subscription 'xxx'. Please try another size or deploy to a different location or zones. See https://aka.ms/azureskunotavailable for details.'.'."},{"code":"InvalidTemplateDeployment","message":"The template deployment failed with error: 'The resource with id: '/subscriptions/xxxx/resourceGroups/rgNetSecLab/providers/Microsoft.Compute/virtualMachines/VM-Kali' failed validation with message: 'The requested size for resource '/subscriptions/xxxx/resourceGroups/rgNetSecLab/providers/Microsoft.Compute/virtualMachines/VM-Kali' is currently not available in location 'eastus2' zones '' for subscription 'xxxx'. Please try another size or deploy to a different location or zones. See https://aka.ms/azureskunotavailable for details.'.'."},{"code":"InvalidTemplateDeployment","message":"The template deployment failed with error: 'The resource with id: '/subscriptions/xxxx/resourceGroups/rgNetSecLab/providers/Microsoft.Compute/virtualMachines/VM-Win2019' failed validation with message: 'The requested size for resource '/subscriptions/xxxx/resourceGroups/rgNetSecLab/providers/Microsoft.Compute/virtualMachines/VM-Win2019' is currently not available in location 'eastus2' zones '' for subscription 'xxxx'. Please try another size or deploy to a different location or zones. See https://aka.ms/azureskunotavailable for details.'.'."}],"message":"Multiple error occurred: BadRequest,BadRequest,BadRequest. Please see details."}