### PR TITLE
Fixed issue when Get-AZResources return object with Data property

### DIFF
--- a/Cross Product/DNS - Find Dangling DNS Records/AzDanglingDomain/Export/Get-DanglingDnsRecords.ps1
+++ b/Cross Product/DNS - Find Dangling DNS Records/AzDanglingDomain/Export/Get-DanglingDnsRecords.ps1
@@ -150,6 +150,7 @@ Function Get-AZResourcesHash {
         Write-Progress $ProgessActivity -Status "$($percentage.ToString('P')) Complete ($skipRecords/$numberOfResources):" -PercentComplete ($percentage*100)
 
         $Resources = Get-AZResources -startId $maxRecords -endId $skipRecords -query $query
+        if ($Resources.Data -is [System.Collections.Generic.IList[psobject]]) {$Resources = $Resources.Data}
     
         $Resources |  ForEach-Object `
         { 


### PR DESCRIPTION
In my case Get-AZResources returns a single object with the items in the Data property.

Part of the returned JSON file (anonymized):
```
{
  "totalRecords": 85,
  "count": 85,
  "data": [
    {
      "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cloud-shell-storage-westeurope/providers/Microsoft.Storage/storageAccounts/000000000000000000000000",
      "tenantId": "00000000-0000-0000-0000-000000000000",
      "subscriptionId": "00000000-0000-0000-0000-000000000000",
      "type": "microsoft.storage/storageaccounts",
      "resourceGroup": "cloud-shell-storage-westeurope",
      "name": "000000000000000000000000",
      "dnsEndpoint": "000000000000000000000000.blob.core.windows.net",
      "dnsEndpoints": [
        "000000000000000000000000.blob.core.windows.net"
      ],
      "properties": {
        "provisioningState": "Succeeded",
```