### PR TITLE
Update Kali Image to 2022 version

### DIFF
--- a/Azure WAF/Lab Template - WAF Attack Testing Lab/AzNetSecdeploy_Juice-Shop_AZFW-Rules_Updated.json
+++ b/Azure WAF/Lab Template - WAF Attack Testing Lab/AzNetSecdeploy_Juice-Shop_AZFW-Rules_Updated.json
@@ -1720,7 +1720,7 @@
       "plan": {
         "name": "kali",
         "publisher": "kali-linux",
-        "product": "kali-linux"
+        "product": "kali"
       },
       "properties": {
         "hardwareProfile": {
@@ -1736,9 +1736,9 @@
           },
           "imageReference": {
             "publisher": "kali-linux",
-            "offer": "kali-linux",
+            "offer": "kali",
             "sku": "kali",
-            "version": "2019.2.0"
+            "version": "latest"
           }
         },
         "networkProfile": {


### PR DESCRIPTION
Kali 2019 has been deprecated in Azure Marketplace and needs to use the latest version.