### PR TITLE
change "exit" to "return"

### DIFF
--- a/Cross Product/DNS - Find Dangling DNS Records/AzDanglingDomain/Export/Get-DanglingDnsRecords.ps1
+++ b/Cross Product/DNS - Find Dangling DNS Records/AzDanglingDomain/Export/Get-DanglingDnsRecords.ps1
@@ -754,7 +754,7 @@ Function Get-DanglingDnsRecords {
 
         if ($null -eq $inputCNameList) {
             Write-Warning "No Records found in input file, please check the file.."
-            exit
+            return
         }
         else {
             Add-ResourceProvider $inputCNameList


### PR DESCRIPTION
As "exit" terminates PowerShell window itself, it would seem script is crashed for customer perspective. Shouldn't we change it from "exit" to "return"?