### PR TITLE
Added new Sentinel Block IP WAF playbook template that supports AFD Standard and Premium WAF updates

### DIFF
--- a/Azure WAF/Playbook - WAF Sentinel Playbook Block IP - New/README.md
+++ b/Azure WAF/Playbook - WAF Sentinel Playbook Block IP - New/README.md
@@ -1,0 +1,24 @@
+# Sentinel Playbook - Block IP - New
+
+[![Deploy to Azure](https://aka.ms/deploytoazurebutton)](https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2Fshabaz-github%2FAzure-Network-Security%2Fmaster%2FAzure%2520WAF%2FPlaybook%2520-%2520WAF%2520Sentinel%2520Playbook%2520Block%2520IP%2520-%2520New%2Ftemplate.json)
+
+This Logic App Playbook for Sentinel will add the source IP address passed from the Sentinel Incident to a custom WAF rule blocking the IP. 
+
+This new playbook will now support Front Door Standard and Premium WAF policies along with the App Gateway WAF policies.
+
+## Step-by-step documentation
+If you'd like more detailed step-by-step instructions on how to deploy this playbook, visit our Tech Community blog post https://aka.ms/wafsentinelintegration-techcommunity and check out the _Respond to Incidents with Playbooks_ section.
+
+## Contributing
+
+This project welcomes contributions and suggestions.  Most contributions require you to agree to a
+Contributor License Agreement (CLA) declaring that you have the right to, and actually do, grant us
+the rights to use your contribution. For details, visit https://cla.opensource.microsoft.com.
+
+When you submit a pull request, a CLA bot will automatically determine whether you need to provide
+a CLA and decorate the PR appropriately (e.g., status check, comment). Simply follow the instructions
+provided by the bot. You will only need to do this once across all repos using our CLA.
+
+This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/).
+For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or
+contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.

--- a/Azure WAF/Playbook - WAF Sentinel Playbook Block IP - New/template.json
+++ b/Azure WAF/Playbook - WAF Sentinel Playbook Block IP - New/template.json
@@ -1,0 +1,2077 @@
+{
+    "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+    "contentVersion": "1.0.0.0",
+    "parameters": {
+        "PlaybookName": {
+            "defaultValue": "Block-IPAzureWAF",
+            "type": "string",
+            "metadata": {
+                "description": "Name of the playbook."
+            }
+        },
+        "UserName": {
+            "defaultValue": "<username>@<domain>",
+            "type": "string",
+            "metadata": {
+                "description": "Azure AD account to be used to create Logic App connections."
+            }
+        },
+        "appgatewayID":{
+            "type":"string",
+            "defaultValue":"Null",
+            "metadata": {
+                "description": "Resource ID of the application gateway that has the WAF policy deployed with it"
+            }
+        },
+        "frontdoorID":{
+            "type":"string",
+            "defaultValue":"Null",
+            "metadata": {
+                "description": "Resource ID of the frontdoor standard/premium instance that has the WAF policy deployed with it"
+            }
+        }
+    },
+    "variables": {
+        "AzureSentinelConnectionName": "[concat('azuresentinel-', parameters('PlaybookName'))]"
+    },
+    "resources": [
+        {
+            "type": "Microsoft.Web/connections",
+            "apiVersion": "2016-06-01",
+            "name": "[variables('AzureSentinelConnectionName')]",
+            "location": "[resourceGroup().location]",
+            "properties": {
+                "displayName": "[parameters('UserName')]",
+                "customParameterValues": {
+                },
+                "api": {
+                    "id": "[concat('/subscriptions/', subscription().subscriptionId, '/providers/Microsoft.Web/locations/', resourceGroup().location, '/managedApis/azuresentinel')]"
+                }
+            }
+        },
+        {
+            "type": "Microsoft.Logic/workflows",
+            "apiVersion": "2017-07-01",
+            "name": "[parameters('PlaybookName')]",
+            "location": "[resourceGroup().location]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/connections', variables('AzureSentinelConnectionName'))]"
+            ],
+            "identity": {
+                "principalId": "",
+                "tenantId": "",
+                "type": "SystemAssigned"
+            },
+            "properties": {
+                "state": "Enabled",
+                "definition": {
+                    "$schema": "https://schema.management.azure.com/providers/Microsoft.Logic/schemas/2016-06-01/workflowdefinition.json#",
+                    "contentVersion": "1.0.0.0",
+                    "parameters": {
+                        "$connections": {
+                            "defaultValue": {},
+                            "type": "Object"
+                        }
+                    },
+                    "triggers": {
+                        "When_a_response_to_an_Azure_Sentinel_alert_is_triggered": {
+                            "type": "ApiConnectionWebhook",
+                            "inputs": {
+                                "body": {
+                                    "callback_url": "@{listCallbackUrl()}"
+                                },
+                                "host": {
+                                    "connection": {
+                                        "name": "@parameters('$connections')['azuresentinel']['connectionId']"
+                                    }
+                                },
+                                "path": "/subscribe"
+                            }
+                        }
+                    },
+                    "actions": {
+                        "Check_WAF_Type": {
+                            "actions": {
+                                "For_each_5": {
+                                    "foreach": "@body('Parse_Front_Door')?['value']",
+                                    "actions": {
+                                        "Add_Custom_Rules_to_Variable": {
+                                            "foreach": "@body('Parse_WAF_Policy_Rules1')?['properties']?['customRules']?['rules']",
+                                            "actions": {
+                                                "Check_for_Existing_SentinelBlockIP_Rule": {
+                                                    "actions": {
+                                                        "Loop_Match_Conditions": {
+                                                            "foreach": "@items('Add_Custom_Rules_to_Variable')['matchConditions']",
+                                                            "actions": {
+                                                                "Add_AttackerIP_to_MatchValue": {
+                                                                    "runAfter": {
+                                                                        "Set_MatchValue": [
+                                                                            "Succeeded"
+                                                                        ]
+                                                                    },
+                                                                    "type": "AppendToArrayVariable",
+                                                                    "inputs": {
+                                                                        "name": "MatchValue",
+                                                                        "value": "@variables('AttackerIP')"
+                                                                    }
+                                                                },
+                                                                "Add_Modified_Rule_to_Array": {
+                                                                    "runAfter": {
+                                                                        "Add_AttackerIP_to_MatchValue": [
+                                                                            "Succeeded"
+                                                                        ]
+                                                                    },
+                                                                    "type": "AppendToArrayVariable",
+                                                                    "inputs": {
+                                                                        "name": "Rules",
+                                                                        "value": {
+                                                                            "action": "@{items('Add_Custom_Rules_to_Variable')?['action']}",
+                                                                            "enabledState": "@{items('Add_Custom_Rules_to_Variable')?['enabledState']}",
+                                                                            "matchConditions": [
+                                                                                {
+                                                                                    "matchValue": "@variables('MatchValue')",
+                                                                                    "matchVariable": "@{items('Loop_Match_Conditions')?['matchVariable']}",
+                                                                                    "negateCondition": "@items('Loop_Match_Conditions')?['negateCondition']",
+                                                                                    "operator": "@{items('Loop_Match_Conditions')?['operator']}",
+                                                                                    "transforms": "@items('Loop_Match_Conditions')?['transforms']"
+                                                                                }
+                                                                            ],
+                                                                            "name": "@{items('Add_Custom_Rules_to_Variable')?['name']}",
+                                                                            "priority": "@items('Add_Custom_Rules_to_Variable')?['priority']",
+                                                                            "rateLimitDurationInMinutes": "@items('Add_Custom_Rules_to_Variable')?['rateLimitDurationInMinutes']",
+                                                                            "rateLimitThreshold": "@items('Add_Custom_Rules_to_Variable')?['rateLimitThreshold']",
+                                                                            "ruleType": "@{items('Add_Custom_Rules_to_Variable')?['ruleType']}"
+                                                                        }
+                                                                    }
+                                                                },
+                                                                "Set_MatchValue": {
+                                                                    "runAfter": {},
+                                                                    "type": "SetVariable",
+                                                                    "inputs": {
+                                                                        "name": "MatchValue",
+                                                                        "value": "@items('Loop_Match_Conditions')?['matchValue']"
+                                                                    }
+                                                                }
+                                                            },
+                                                            "runAfter": {},
+                                                            "type": "Foreach"
+                                                        }
+                                                    },
+                                                    "runAfter": {},
+                                                    "else": {
+                                                        "actions": {
+                                                            "Append_Rules_to_Array": {
+                                                                "runAfter": {},
+                                                                "type": "AppendToArrayVariable",
+                                                                "inputs": {
+                                                                    "name": "Rules",
+                                                                    "value": {
+                                                                        "action": "@{items('Add_Custom_Rules_to_Variable')?['action']}",
+                                                                        "enabledState": "@{items('Add_Custom_Rules_to_Variable')?['enabledState']}",
+                                                                        "matchConditions": "@items('Add_Custom_Rules_to_Variable')?['matchConditions']",
+                                                                        "name": "@{items('Add_Custom_Rules_to_Variable')?['name']}",
+                                                                        "priority": "@items('Add_Custom_Rules_to_Variable')?['priority']",
+                                                                        "rateLimitDurationInMinutes": "@items('Add_Custom_Rules_to_Variable')?['rateLimitDurationInMinutes']",
+                                                                        "rateLimitThreshold": "@items('Add_Custom_Rules_to_Variable')?['rateLimitThreshold']",
+                                                                        "ruleType": "@{items('Add_Custom_Rules_to_Variable')?['ruleType']}"
+                                                                    }
+                                                                }
+                                                            }
+                                                        }
+                                                    },
+                                                    "expression": {
+                                                        "and": [
+                                                            {
+                                                                "equals": [
+                                                                    "@items('Add_Custom_Rules_to_Variable')?['name']",
+                                                                    "SentinelBlockIP"
+                                                                ]
+                                                            }
+                                                        ]
+                                                    },
+                                                    "type": "If"
+                                                }
+                                            },
+                                            "runAfter": {
+                                                "Parse_WAF_Policy_Rules1": [
+                                                    "Succeeded"
+                                                ]
+                                            },
+                                            "type": "Foreach"
+                                        },
+                                        "Check_for_SentinelBlockIP_Rule": {
+                                            "actions": {},
+                                            "runAfter": {
+                                                "Add_Custom_Rules_to_Variable": [
+                                                    "Succeeded"
+                                                ]
+                                            },
+                                            "else": {
+                                                "actions": {
+                                                    "Add_Custom_Rule_to_Rules_Array": {
+                                                        "runAfter": {
+                                                            "Create_Unique_Priority": [
+                                                                "Succeeded"
+                                                            ]
+                                                        },
+                                                        "type": "AppendToArrayVariable",
+                                                        "inputs": {
+                                                            "name": "Rules",
+                                                            "value": {
+                                                                "action": "Block",
+                                                                "enabledState": "Enabled",
+                                                                "matchConditions": [
+                                                                    {
+                                                                        "matchValue": [
+                                                                            "@{variables('AttackerIP')}"
+                                                                        ],
+                                                                        "matchVariable": "RemoteAddr",
+                                                                        "negateCondition": false,
+                                                                        "operator": "IPMatch",
+                                                                        "transforms": []
+                                                                    }
+                                                                ],
+                                                                "name": "SentinelBlockIP",
+                                                                "priority": "@variables('Priority')",
+                                                                "rateLimitDurationInMinutes": 1,
+                                                                "rateLimitThreshold": 100,
+                                                                "ruleType": "MatchRule"
+                                                            }
+                                                        }
+                                                    },
+                                                    "Create_Unique_Priority": {
+                                                        "actions": {
+                                                            "Increment_Priority": {
+                                                                "runAfter": {},
+                                                                "type": "IncrementVariable",
+                                                                "inputs": {
+                                                                    "name": "Priority",
+                                                                    "value": 5
+                                                                }
+                                                            }
+                                                        },
+                                                        "runAfter": {},
+                                                        "expression": "@not(contains(variables('Rules'), variables('Priority')))",
+                                                        "limit": {
+                                                            "count": 60,
+                                                            "timeout": "PT1H"
+                                                        },
+                                                        "type": "Until"
+                                                    }
+                                                }
+                                            },
+                                            "expression": {
+                                                "and": [
+                                                    {
+                                                        "contains": [
+                                                            "@string(variables('Rules'))",
+                                                            "SentinelBlockIP"
+                                                        ]
+                                                    }
+                                                ]
+                                            },
+                                            "type": "If"
+                                        },
+                                        "Create_JSON_Rules_Object_from_Array": {
+                                            "runAfter": {
+                                                "Check_for_SentinelBlockIP_Rule": [
+                                                    "Succeeded"
+                                                ]
+                                            },
+                                            "type": "Compose",
+                                            "inputs": "@variables('Rules')"
+                                        },
+                                        "Get_WAF_Policy_Rules1": {
+                                            "runAfter": {},
+                                            "type": "Http",
+                                            "inputs": {
+                                                "authentication": {
+                                                    "type": "ManagedServiceIdentity"
+                                                },
+                                                "method": "GET",
+                                                "uri": "https://management.azure.com@{items('For_each_5')?['properties']?['parameters']?['wafPolicy']?['id']}?api-version=2020-11-01"
+                                            }
+                                        },
+                                        "Parse_WAF_Policy_Rules1": {
+                                            "runAfter": {
+                                                "Get_WAF_Policy_Rules1": [
+                                                    "Succeeded"
+                                                ]
+                                            },
+                                            "type": "ParseJson",
+                                            "inputs": {
+                                                "content": "@body('Get_WAF_Policy_Rules1')",
+                                                "schema": {
+                                                    "properties": {
+                                                        "id": {
+                                                            "type": "string"
+                                                        },
+                                                        "location": {
+                                                            "type": "string"
+                                                        },
+                                                        "name": {
+                                                            "type": "string"
+                                                        },
+                                                        "properties": {
+                                                            "properties": {
+                                                                "customRules": {
+                                                                    "properties": {
+                                                                        "rules": {
+                                                                            "items": {
+                                                                                "properties": {
+                                                                                    "action": {
+                                                                                        "type": "string"
+                                                                                    },
+                                                                                    "enabledState": {
+                                                                                        "type": "string"
+                                                                                    },
+                                                                                    "matchConditions": {
+                                                                                        "items": {
+                                                                                            "properties": {
+                                                                                                "matchValue": {
+                                                                                                    "items": {
+                                                                                                        "type": "string"
+                                                                                                    },
+                                                                                                    "type": "array"
+                                                                                                },
+                                                                                                "matchVariable": {
+                                                                                                    "type": "string"
+                                                                                                },
+                                                                                                "negateCondition": {
+                                                                                                    "type": "boolean"
+                                                                                                },
+                                                                                                "operator": {
+                                                                                                    "type": "string"
+                                                                                                },
+                                                                                                "selector": {},
+                                                                                                "transforms": {
+                                                                                                    "type": "array"
+                                                                                                }
+                                                                                            },
+                                                                                            "required": [
+                                                                                                "matchVariable",
+                                                                                                "selector",
+                                                                                                "operator",
+                                                                                                "negateCondition",
+                                                                                                "matchValue",
+                                                                                                "transforms"
+                                                                                            ],
+                                                                                            "type": "object"
+                                                                                        },
+                                                                                        "type": "array"
+                                                                                    },
+                                                                                    "name": {
+                                                                                        "type": "string"
+                                                                                    },
+                                                                                    "priority": {
+                                                                                        "type": "integer"
+                                                                                    },
+                                                                                    "rateLimitDurationInMinutes": {
+                                                                                        "type": "integer"
+                                                                                    },
+                                                                                    "rateLimitThreshold": {
+                                                                                        "type": "integer"
+                                                                                    },
+                                                                                    "ruleType": {
+                                                                                        "type": "string"
+                                                                                    }
+                                                                                },
+                                                                                "required": [
+                                                                                    "name",
+                                                                                    "enabledState",
+                                                                                    "priority",
+                                                                                    "ruleType",
+                                                                                    "rateLimitDurationInMinutes",
+                                                                                    "rateLimitThreshold",
+                                                                                    "matchConditions",
+                                                                                    "action"
+                                                                                ],
+                                                                                "type": "object"
+                                                                            },
+                                                                            "type": "array"
+                                                                        }
+                                                                    },
+                                                                    "type": "object"
+                                                                },
+                                                                "frontendEndpointLinks": {
+                                                                    "type": "array"
+                                                                },
+                                                                "managedRules": {
+                                                                    "properties": {
+                                                                        "managedRuleSets": {
+                                                                            "items": {
+                                                                                "properties": {
+                                                                                    "exclusions": {
+                                                                                        "type": "array"
+                                                                                    },
+                                                                                    "ruleGroupOverrides": {
+                                                                                        "type": "array"
+                                                                                    },
+                                                                                    "ruleSetAction": {
+                                                                                        "type": [
+                                                                                            "string",
+                                                                                            "null"
+                                                                                        ]
+                                                                                    },
+                                                                                    "ruleSetType": {
+                                                                                        "type": "string"
+                                                                                    },
+                                                                                    "ruleSetVersion": {
+                                                                                        "type": "string"
+                                                                                    }
+                                                                                },
+                                                                                "required": [
+                                                                                    "ruleSetType",
+                                                                                    "ruleSetVersion",
+                                                                                    "ruleSetAction",
+                                                                                    "ruleGroupOverrides",
+                                                                                    "exclusions"
+                                                                                ],
+                                                                                "type": "object"
+                                                                            },
+                                                                            "type": "array"
+                                                                        }
+                                                                    },
+                                                                    "type": "object"
+                                                                },
+                                                                "policySettings": {
+                                                                    "properties": {
+                                                                        "customBlockResponseBody": {},
+                                                                        "customBlockResponseStatusCode": {},
+                                                                        "enabledState": {
+                                                                            "type": [
+                                                                                "string",
+                                                                                "null"
+                                                                            ]
+                                                                        },
+                                                                        "mode": {
+                                                                            "type": "string"
+                                                                        },
+                                                                        "redirectUrl": {},
+                                                                        "requestBodyCheck": {
+                                                                            "type": [
+                                                                                "string",
+                                                                                "null"
+                                                                            ]
+                                                                        }
+                                                                    },
+                                                                    "type": "object"
+                                                                },
+                                                                "provisioningState": {
+                                                                    "type": "string"
+                                                                },
+                                                                "resourceState": {
+                                                                    "type": "string"
+                                                                },
+                                                                "routingRuleLinks": {
+                                                                    "type": "array"
+                                                                },
+                                                                "securityPolicyLinks": {
+                                                                    "items": {
+                                                                        "properties": {
+                                                                            "id": {
+                                                                                "type": "string"
+                                                                            }
+                                                                        },
+                                                                        "required": [
+                                                                            "id"
+                                                                        ],
+                                                                        "type": "object"
+                                                                    },
+                                                                    "type": "array"
+                                                                }
+                                                            },
+                                                            "type": "object"
+                                                        },
+                                                        "sku": {
+                                                            "properties": {
+                                                                "name": {
+                                                                    "type": "string"
+                                                                }
+                                                            },
+                                                            "type": "object"
+                                                        },
+                                                        "tags": {
+                                                            "properties": {
+                                                                "createddate": {
+                                                                    "type": "string"
+                                                                },
+                                                                "owner": {
+                                                                    "type": "string"
+                                                                }
+                                                            },
+                                                            "type": "object"
+                                                        },
+                                                        "type": {
+                                                            "type": "string"
+                                                        }
+                                                    },
+                                                    "type": "object"
+                                                }
+                                            }
+                                        },
+                                        "Update_WAF_Policy": {
+                                            "runAfter": {
+                                                "Create_JSON_Rules_Object_from_Array": [
+                                                    "Succeeded"
+                                                ]
+                                            },
+                                            "type": "Http",
+                                            "inputs": {
+                                                "authentication": {
+                                                    "type": "ManagedServiceIdentity"
+                                                },
+                                                "body": {
+                                                    "id": "@{items('For_each_5')?['properties']?['parameters']?['wafPolicy']?['id']}",
+                                                    "location": "@{body('Parse_WAF_Policy_Rules1')?['location']}",
+                                                    "name": "@{body('Parse_WAF_Policy_Rules1')?['name']}",
+                                                    "properties": {
+                                                        "customRules": {
+                                                            "rules": "@outputs('Create_JSON_Rules_Object_from_Array')"
+                                                        },
+                                                        "managedRules": "@body('Parse_WAF_Policy_Rules1')?['properties']?['managedRules']",
+                                                        "policySettings": "@body('Parse_WAF_Policy_Rules1')?['properties']?['policySettings']"
+                                                    },
+                                                    "sku": {
+                                                        "name": "@{body('Parse_WAF_Policy_Rules1')?['sku']?['name']}"
+                                                    },
+                                                    "type": "@{body('Parse_WAF_Policy_Rules1')?['type']}"
+                                                },
+                                                "method": "PUT",
+                                                "uri": "https://management.azure.com@{items('For_each_5')?['properties']?['parameters']?['wafPolicy']?['id']}?api-version=2020-11-01"
+                                            }
+                                        }
+                                    },
+                                    "runAfter": {
+                                        "Parse_Front_Door": [
+                                            "Succeeded"
+                                        ]
+                                    },
+                                    "type": "Foreach",
+                                    "runtimeConfiguration": {
+                                        "concurrency": {
+                                            "repetitions": 1
+                                        }
+                                    }
+                                },
+                                "Get_Front_Door": {
+                                    "runAfter": {},
+                                    "type": "Http",
+                                    "inputs": {
+                                        "authentication": {
+                                            "type": "ManagedServiceIdentity"
+                                        },
+                                        "method": "GET",
+                                        "uri": "https://management.azure.com@{variables('ResourceID2')}/securityPolicies?api-version=2021-06-01"
+                                    }
+                                },
+                                "Parse_Front_Door": {
+                                    "runAfter": {
+                                        "Get_Front_Door": [
+                                            "Succeeded"
+                                        ]
+                                    },
+                                    "type": "ParseJson",
+                                    "inputs": {
+                                        "content": "@body('Get_Front_Door')",
+                                        "schema": {
+                                            "properties": {
+                                                "value": {
+                                                    "items": {
+                                                        "properties": {
+                                                            "id": {
+                                                                "type": "string"
+                                                            },
+                                                            "name": {
+                                                                "type": "string"
+                                                            },
+                                                            "properties": {
+                                                                "properties": {
+                                                                    "deploymentStatus": {
+                                                                        "type": "string"
+                                                                    },
+                                                                    "parameters": {
+                                                                        "properties": {
+                                                                            "associations": {
+                                                                                "items": {
+                                                                                    "properties": {
+                                                                                        "domains": {
+                                                                                            "items": {
+                                                                                                "properties": {
+                                                                                                    "id": {
+                                                                                                        "type": "string"
+                                                                                                    },
+                                                                                                    "isActive": {
+                                                                                                        "type": "boolean"
+                                                                                                    }
+                                                                                                },
+                                                                                                "required": [
+                                                                                                    "isActive",
+                                                                                                    "id"
+                                                                                                ],
+                                                                                                "type": "object"
+                                                                                            },
+                                                                                            "type": "array"
+                                                                                        },
+                                                                                        "patternsToMatch": {
+                                                                                            "items": {
+                                                                                                "type": "string"
+                                                                                            },
+                                                                                            "type": "array"
+                                                                                        }
+                                                                                    },
+                                                                                    "required": [
+                                                                                        "domains",
+                                                                                        "patternsToMatch"
+                                                                                    ],
+                                                                                    "type": "object"
+                                                                                },
+                                                                                "type": "array"
+                                                                            },
+                                                                            "type": {
+                                                                                "type": "string"
+                                                                            },
+                                                                            "wafPolicy": {
+                                                                                "properties": {
+                                                                                    "id": {
+                                                                                        "type": "string"
+                                                                                    }
+                                                                                },
+                                                                                "type": "object"
+                                                                            }
+                                                                        },
+                                                                        "type": "object"
+                                                                    },
+                                                                    "provisioningState": {
+                                                                        "type": "string"
+                                                                    }
+                                                                },
+                                                                "type": "object"
+                                                            },
+                                                            "type": {
+                                                                "type": "string"
+                                                            }
+                                                        },
+                                                        "required": [
+                                                            "id",
+                                                            "type",
+                                                            "name",
+                                                            "properties"
+                                                        ],
+                                                        "type": "object"
+                                                    },
+                                                    "type": "array"
+                                                }
+                                            },
+                                            "type": "object"
+                                        }
+                                    }
+                                }
+                            },
+                            "runAfter": {
+                                "Set_Variables_from_Entities": [
+                                    "Succeeded"
+                                ]
+                            },
+                            "else": {
+                                "actions": {
+                                    "Compose": {
+                                        "runAfter": {
+                                            "Condition_4": [
+                                                "Succeeded"
+                                            ]
+                                        },
+                                        "type": "Compose",
+                                        "inputs": "@variables('Rules')"
+                                    },
+                                    "Condition_4": {
+                                        "actions": {},
+                                        "runAfter": {
+                                            "For_each": [
+                                                "Succeeded"
+                                            ]
+                                        },
+                                        "else": {
+                                            "actions": {
+                                                "Append_to_array_variable_4": {
+                                                    "runAfter": {
+                                                        "Until": [
+                                                            "Succeeded"
+                                                        ]
+                                                    },
+                                                    "type": "AppendToArrayVariable",
+                                                    "inputs": {
+                                                        "name": "Rules",
+                                                        "value": {
+                                                            "action": "Block",
+                                                            "matchConditions": [
+                                                                {
+                                                                    "matchValues": [
+                                                                        "@{variables('AttackerIP')}"
+                                                                    ],
+                                                                    "matchVariables": [
+                                                                        {
+                                                                            "variableName": "RemoteAddr"
+                                                                        }
+                                                                    ],
+                                                                    "negationConditon": false,
+                                                                    "operator": "IPMatch",
+                                                                    "transforms": []
+                                                                }
+                                                            ],
+                                                            "name": "SentinelBlockIP",
+                                                            "priority": "@variables('Priority')",
+                                                            "ruleType": "MatchRule"
+                                                        }
+                                                    }
+                                                },
+                                                "Until": {
+                                                    "actions": {
+                                                        "Increment_variable": {
+                                                            "runAfter": {},
+                                                            "type": "IncrementVariable",
+                                                            "inputs": {
+                                                                "name": "Priority",
+                                                                "value": 5
+                                                            }
+                                                        }
+                                                    },
+                                                    "runAfter": {},
+                                                    "expression": "@not(contains(variables('Rules'), variables('Priority')))",
+                                                    "limit": {
+                                                        "count": 60,
+                                                        "timeout": "PT1H"
+                                                    },
+                                                    "type": "Until"
+                                                }
+                                            }
+                                        },
+                                        "expression": {
+                                            "and": [
+                                                {
+                                                    "contains": [
+                                                        "@string(variables('Rules'))",
+                                                        "SentinelBlockIP"
+                                                    ]
+                                                }
+                                            ]
+                                        },
+                                        "type": "If"
+                                    },
+                                    "For_each": {
+                                        "foreach": "@body('Parse_AppGW_Policy')?['properties']?['customRules']",
+                                        "actions": {
+                                            "Check_for_Existing_Sentinel_Rule": {
+                                                "actions": {
+                                                    "For_each_2": {
+                                                        "foreach": "@items('For_each')['matchConditions']",
+                                                        "actions": {
+                                                            "Append_to_array_variable_2": {
+                                                                "runAfter": {
+                                                                    "Set_variable_4": [
+                                                                        "Succeeded"
+                                                                    ]
+                                                                },
+                                                                "type": "AppendToArrayVariable",
+                                                                "inputs": {
+                                                                    "name": "MatchValue",
+                                                                    "value": "@variables('AttackerIP')"
+                                                                }
+                                                            },
+                                                            "Append_to_array_variable_3": {
+                                                                "runAfter": {
+                                                                    "Append_to_array_variable_2": [
+                                                                        "Succeeded"
+                                                                    ]
+                                                                },
+                                                                "type": "AppendToArrayVariable",
+                                                                "inputs": {
+                                                                    "name": "Rules",
+                                                                    "value": {
+                                                                        "action": "@{items('For_each')?['action']}",
+                                                                        "matchConditions": [
+                                                                            {
+                                                                                "matchValues": "@variables('MatchValue')",
+                                                                                "matchVariables": [
+                                                                                    {
+                                                                                        "variableName": "RemoteAddr"
+                                                                                    }
+                                                                                ],
+                                                                                "negationConditon": false,
+                                                                                "operator": "IPMatch",
+                                                                                "transforms": []
+                                                                            }
+                                                                        ],
+                                                                        "name": "@{items('For_each')?['name']}",
+                                                                        "priority": "@items('For_each')?['priority']",
+                                                                        "ruleType": "@{items('For_each')?['ruleType']}"
+                                                                    }
+                                                                }
+                                                            },
+                                                            "Set_variable_4": {
+                                                                "runAfter": {},
+                                                                "type": "SetVariable",
+                                                                "inputs": {
+                                                                    "name": "MatchValue",
+                                                                    "value": "@items('For_each_2')?['matchValues']"
+                                                                }
+                                                            }
+                                                        },
+                                                        "runAfter": {},
+                                                        "type": "Foreach"
+                                                    }
+                                                },
+                                                "runAfter": {},
+                                                "else": {
+                                                    "actions": {
+                                                        "Append_to_array_variable": {
+                                                            "runAfter": {},
+                                                            "type": "AppendToArrayVariable",
+                                                            "inputs": {
+                                                                "name": "Rules",
+                                                                "value": {
+                                                                    "action": "@{items('For_each')?['action']}",
+                                                                    "matchConditions": "@items('For_each')?['matchConditions']",
+                                                                    "name": "@{items('For_each')?['name']}",
+                                                                    "priority": "@items('For_each')?['priority']",
+                                                                    "ruleType": "@{items('For_each')?['ruleType']}"
+                                                                }
+                                                            }
+                                                        }
+                                                    }
+                                                },
+                                                "expression": {
+                                                    "and": [
+                                                        {
+                                                            "equals": [
+                                                                "@items('For_each')?['name']",
+                                                                "SentinelBlockIP"
+                                                            ]
+                                                        }
+                                                    ]
+                                                },
+                                                "type": "If"
+                                            }
+                                        },
+                                        "runAfter": {
+                                            "Parse_AppGW_Policy": [
+                                                "Succeeded"
+                                            ]
+                                        },
+                                        "type": "Foreach"
+                                    },
+                                    "Get_AppGW_WAF_Policy": {
+                                        "runAfter": {
+                                            "Parse_App_Gateway": [
+                                                "Succeeded"
+                                            ]
+                                        },
+                                        "type": "Http",
+                                        "inputs": {
+                                            "authentication": {
+                                                "type": "ManagedServiceIdentity"
+                                            },
+                                            "method": "GET",
+                                            "uri": "https://management.azure.com@{body('Parse_App_Gateway')?['properties']?['firewallPolicy']?['id']}?api-version=2020-05-01"
+                                        }
+                                    },
+                                    "Get_App_Gateway": {
+                                        "runAfter": {},
+                                        "type": "Http",
+                                        "inputs": {
+                                            "authentication": {
+                                                "type": "ManagedServiceIdentity"
+                                            },
+                                            "method": "GET",
+                                            "uri": "https://management.azure.com@{variables('ResourceID1')}?api-version=2020-05-01"
+                                        }
+                                    },
+                                    "HTTP": {
+                                        "runAfter": {
+                                            "Compose": [
+                                                "Succeeded"
+                                            ]
+                                        },
+                                        "type": "Http",
+                                        "inputs": {
+                                            "authentication": {
+                                                "type": "ManagedServiceIdentity"
+                                            },
+                                            "body": {
+                                                "id": "@body('Parse_AppGW_Policy')?['id']",
+                                                "location": "@body('Parse_AppGW_Policy')?['location']",
+                                                "name": "@body('Parse_AppGW_Policy')?['name']",
+                                                "properties": {
+                                                    "applicationGateways": "@body('Parse_AppGW_Policy')?['properties']?['applicationGateways']",
+                                                    "customRules": "@outputs('Compose')",
+                                                    "managedRules": "@body('Parse_AppGW_Policy')?['properties']?['managedRules']",
+                                                    "policySettings": "@body('Parse_AppGW_Policy')?['properties']?['policySettings']"
+                                                },
+                                                "type": "@body('Parse_AppGW_Policy')?['type']"
+                                            },
+                                            "method": "PUT",
+                                            "uri": "https://management.azure.com@{body('Parse_App_Gateway')?['properties']?['firewallPolicy']?['id']}?api-version=2020-05-01"
+                                        }
+                                    },
+                                    "Parse_AppGW_Policy": {
+                                        "runAfter": {
+                                            "Get_AppGW_WAF_Policy": [
+                                                "Succeeded"
+                                            ]
+                                        },
+                                        "type": "ParseJson",
+                                        "inputs": {
+                                            "content": "@body('Get_AppGW_WAF_Policy')",
+                                            "schema": {
+                                                "properties": {
+                                                    "etag": {
+                                                        "type": "string"
+                                                    },
+                                                    "id": {
+                                                        "type": "string"
+                                                    },
+                                                    "location": {
+                                                        "type": "string"
+                                                    },
+                                                    "name": {
+                                                        "type": "string"
+                                                    },
+                                                    "properties": {
+                                                        "properties": {
+                                                            "applicationGateways": {
+                                                                "items": {
+                                                                    "properties": {
+                                                                        "id": {
+                                                                            "type": "string"
+                                                                        }
+                                                                    },
+                                                                    "required": [
+                                                                        "id"
+                                                                    ],
+                                                                    "type": "object"
+                                                                },
+                                                                "type": "array"
+                                                            },
+                                                            "customRules": {
+                                                                "items": {
+                                                                    "properties": {
+                                                                        "action": {
+                                                                            "type": "string"
+                                                                        },
+                                                                        "matchConditions": {
+                                                                            "items": {
+                                                                                "properties": {
+                                                                                    "matchValues": {
+                                                                                        "items": {
+                                                                                            "type": "string"
+                                                                                        },
+                                                                                        "type": "array"
+                                                                                    },
+                                                                                    "matchVariables": {
+                                                                                        "items": {
+                                                                                            "properties": {
+                                                                                                "variableName": {
+                                                                                                    "type": "string"
+                                                                                                }
+                                                                                            },
+                                                                                            "required": [
+                                                                                                "variableName"
+                                                                                            ],
+                                                                                            "type": "object"
+                                                                                        },
+                                                                                        "type": "array"
+                                                                                    },
+                                                                                    "negationConditon": {
+                                                                                        "type": "boolean"
+                                                                                    },
+                                                                                    "operator": {
+                                                                                        "type": "string"
+                                                                                    },
+                                                                                    "transforms": {
+                                                                                        "type": "array"
+                                                                                    }
+                                                                                },
+                                                                                "required": [
+                                                                                    "matchVariables",
+                                                                                    "operator",
+                                                                                    "negationConditon",
+                                                                                    "matchValues",
+                                                                                    "transforms"
+                                                                                ],
+                                                                                "type": "object"
+                                                                            },
+                                                                            "type": "array"
+                                                                        },
+                                                                        "name": {
+                                                                            "type": "string"
+                                                                        },
+                                                                        "priority": {
+                                                                            "type": "integer"
+                                                                        },
+                                                                        "ruleType": {
+                                                                            "type": "string"
+                                                                        },
+                                                                        "skippedManagedRuleSets": {
+                                                                            "type": "array"
+                                                                        }
+                                                                    },
+                                                                    "required": [
+                                                                        "name",
+                                                                        "priority",
+                                                                        "ruleType",
+                                                                        "action",
+                                                                        "matchConditions",
+                                                                        "skippedManagedRuleSets"
+                                                                    ],
+                                                                    "type": "object"
+                                                                },
+                                                                "type": "array"
+                                                            },
+                                                            "managedRules": {
+                                                                "properties": {
+                                                                    "exclusions": {
+                                                                        "type": "array"
+                                                                    },
+                                                                    "managedRuleSets": {
+                                                                        "items": {
+                                                                            "properties": {
+                                                                                "ruleGroupOverrides": {
+                                                                                    "type": "array"
+                                                                                },
+                                                                                "ruleSetType": {
+                                                                                    "type": "string"
+                                                                                },
+                                                                                "ruleSetVersion": {
+                                                                                    "type": "string"
+                                                                                }
+                                                                            },
+                                                                            "required": [
+                                                                                "ruleSetType",
+                                                                                "ruleSetVersion",
+                                                                                "ruleGroupOverrides"
+                                                                            ],
+                                                                            "type": "object"
+                                                                        },
+                                                                        "type": "array"
+                                                                    }
+                                                                },
+                                                                "type": "object"
+                                                            },
+                                                            "policySettings": {
+                                                                "properties": {
+                                                                    "fileUploadLimitInMb": {
+                                                                        "type": "integer"
+                                                                    },
+                                                                    "maxRequestBodySizeInKb": {
+                                                                        "type": "integer"
+                                                                    },
+                                                                    "mode": {
+                                                                        "type": "string"
+                                                                    },
+                                                                    "requestBodyCheck": {
+                                                                        "type": "boolean"
+                                                                    },
+                                                                    "state": {
+                                                                        "type": "string"
+                                                                    }
+                                                                },
+                                                                "type": "object"
+                                                            },
+                                                            "provisioningState": {
+                                                                "type": "string"
+                                                            }
+                                                        },
+                                                        "type": "object"
+                                                    },
+                                                    "type": {
+                                                        "type": "string"
+                                                    }
+                                                },
+                                                "type": "object"
+                                            }
+                                        }
+                                    },
+                                    "Parse_App_Gateway": {
+                                        "runAfter": {
+                                            "Get_App_Gateway": [
+                                                "Succeeded"
+                                            ]
+                                        },
+                                        "type": "ParseJson",
+                                        "inputs": {
+                                            "content": "@body('Get_App_Gateway')",
+                                            "schema": {
+                                                "properties": {
+                                                    "etag": {
+                                                        "type": "string"
+                                                    },
+                                                    "id": {
+                                                        "type": "string"
+                                                    },
+                                                    "location": {
+                                                        "type": "string"
+                                                    },
+                                                    "name": {
+                                                        "type": "string"
+                                                    },
+                                                    "properties": {
+                                                        "properties": {
+                                                            "backendAddressPools": {
+                                                                "items": {
+                                                                    "properties": {
+                                                                        "etag": {
+                                                                            "type": "string"
+                                                                        },
+                                                                        "id": {
+                                                                            "type": "string"
+                                                                        },
+                                                                        "name": {
+                                                                            "type": "string"
+                                                                        },
+                                                                        "properties": {
+                                                                            "properties": {
+                                                                                "backendAddresses": {
+                                                                                    "items": {
+                                                                                        "properties": {
+                                                                                            "fqdn": {
+                                                                                                "type": "string"
+                                                                                            }
+                                                                                        },
+                                                                                        "required": [
+                                                                                            "fqdn"
+                                                                                        ],
+                                                                                        "type": "object"
+                                                                                    },
+                                                                                    "type": "array"
+                                                                                },
+                                                                                "provisioningState": {
+                                                                                    "type": "string"
+                                                                                },
+                                                                                "requestRoutingRules": {
+                                                                                    "items": {
+                                                                                        "properties": {
+                                                                                            "id": {
+                                                                                                "type": "string"
+                                                                                            }
+                                                                                        },
+                                                                                        "required": [
+                                                                                            "id"
+                                                                                        ],
+                                                                                        "type": "object"
+                                                                                    },
+                                                                                    "type": "array"
+                                                                                }
+                                                                            },
+                                                                            "type": "object"
+                                                                        },
+                                                                        "type": {
+                                                                            "type": "string"
+                                                                        }
+                                                                    },
+                                                                    "required": [
+                                                                        "name",
+                                                                        "id",
+                                                                        "etag",
+                                                                        "properties",
+                                                                        "type"
+                                                                    ],
+                                                                    "type": "object"
+                                                                },
+                                                                "type": "array"
+                                                            },
+                                                            "backendHttpSettingsCollection": {
+                                                                "items": {
+                                                                    "properties": {
+                                                                        "etag": {
+                                                                            "type": "string"
+                                                                        },
+                                                                        "id": {
+                                                                            "type": "string"
+                                                                        },
+                                                                        "name": {
+                                                                            "type": "string"
+                                                                        },
+                                                                        "properties": {
+                                                                            "properties": {
+                                                                                "cookieBasedAffinity": {
+                                                                                    "type": "string"
+                                                                                },
+                                                                                "path": {},
+                                                                                "pickHostNameFromBackendAddress": {
+                                                                                    "type": "boolean"
+                                                                                },
+                                                                                "port": {
+                                                                                    "type": "integer"
+                                                                                },
+                                                                                "probe": {
+                                                                                    "properties": {
+                                                                                        "id": {
+                                                                                            "type": "string"
+                                                                                        }
+                                                                                    },
+                                                                                    "type": "object"
+                                                                                },
+                                                                                "protocol": {
+                                                                                    "type": "string"
+                                                                                },
+                                                                                "provisioningState": {
+                                                                                    "type": "string"
+                                                                                },
+                                                                                "requestRoutingRules": {
+                                                                                    "items": {
+                                                                                        "properties": {
+                                                                                            "id": {
+                                                                                                "type": "string"
+                                                                                            }
+                                                                                        },
+                                                                                        "required": [
+                                                                                            "id"
+                                                                                        ],
+                                                                                        "type": "object"
+                                                                                    },
+                                                                                    "type": "array"
+                                                                                },
+                                                                                "requestTimeout": {
+                                                                                    "type": "integer"
+                                                                                }
+                                                                            },
+                                                                            "type": "object"
+                                                                        },
+                                                                        "type": {
+                                                                            "type": "string"
+                                                                        }
+                                                                    },
+                                                                    "required": [
+                                                                        "name",
+                                                                        "id",
+                                                                        "etag",
+                                                                        "properties",
+                                                                        "type"
+                                                                    ],
+                                                                    "type": "object"
+                                                                },
+                                                                "type": "array"
+                                                            },
+                                                            "enableHttp2": {
+                                                                "type": "boolean"
+                                                            },
+                                                            "firewallPolicy": {
+                                                                "properties": {
+                                                                    "id": {
+                                                                        "type": "string"
+                                                                    }
+                                                                },
+                                                                "type": "object"
+                                                            },
+                                                            "frontendIPConfigurations": {
+                                                                "items": {
+                                                                    "properties": {
+                                                                        "etag": {
+                                                                            "type": "string"
+                                                                        },
+                                                                        "id": {
+                                                                            "type": "string"
+                                                                        },
+                                                                        "name": {
+                                                                            "type": "string"
+                                                                        },
+                                                                        "properties": {
+                                                                            "properties": {
+                                                                                "httpListeners": {
+                                                                                    "items": {
+                                                                                        "properties": {
+                                                                                            "id": {
+                                                                                                "type": "string"
+                                                                                            }
+                                                                                        },
+                                                                                        "required": [
+                                                                                            "id"
+                                                                                        ],
+                                                                                        "type": "object"
+                                                                                    },
+                                                                                    "type": "array"
+                                                                                },
+                                                                                "privateIPAllocationMethod": {
+                                                                                    "type": "string"
+                                                                                },
+                                                                                "provisioningState": {
+                                                                                    "type": "string"
+                                                                                },
+                                                                                "publicIPAddress": {
+                                                                                    "properties": {
+                                                                                        "id": {
+                                                                                            "type": "string"
+                                                                                        }
+                                                                                    },
+                                                                                    "type": "object"
+                                                                                }
+                                                                            },
+                                                                            "type": "object"
+                                                                        },
+                                                                        "type": {
+                                                                            "type": "string"
+                                                                        }
+                                                                    },
+                                                                    "required": [
+                                                                        "name",
+                                                                        "id",
+                                                                        "etag",
+                                                                        "type",
+                                                                        "properties"
+                                                                    ],
+                                                                    "type": "object"
+                                                                },
+                                                                "type": "array"
+                                                            },
+                                                            "frontendPorts": {
+                                                                "items": {
+                                                                    "properties": {
+                                                                        "etag": {
+                                                                            "type": "string"
+                                                                        },
+                                                                        "id": {
+                                                                            "type": "string"
+                                                                        },
+                                                                        "name": {
+                                                                            "type": "string"
+                                                                        },
+                                                                        "properties": {
+                                                                            "properties": {
+                                                                                "httpListeners": {
+                                                                                    "items": {
+                                                                                        "properties": {
+                                                                                            "id": {
+                                                                                                "type": "string"
+                                                                                            }
+                                                                                        },
+                                                                                        "required": [
+                                                                                            "id"
+                                                                                        ],
+                                                                                        "type": "object"
+                                                                                    },
+                                                                                    "type": "array"
+                                                                                },
+                                                                                "port": {
+                                                                                    "type": "integer"
+                                                                                },
+                                                                                "provisioningState": {
+                                                                                    "type": "string"
+                                                                                }
+                                                                            },
+                                                                            "type": "object"
+                                                                        },
+                                                                        "type": {
+                                                                            "type": "string"
+                                                                        }
+                                                                    },
+                                                                    "required": [
+                                                                        "name",
+                                                                        "id",
+                                                                        "etag",
+                                                                        "properties",
+                                                                        "type"
+                                                                    ],
+                                                                    "type": "object"
+                                                                },
+                                                                "type": "array"
+                                                            },
+                                                            "gatewayIPConfigurations": {
+                                                                "items": {
+                                                                    "properties": {
+                                                                        "etag": {
+                                                                            "type": "string"
+                                                                        },
+                                                                        "id": {
+                                                                            "type": "string"
+                                                                        },
+                                                                        "name": {
+                                                                            "type": "string"
+                                                                        },
+                                                                        "properties": {
+                                                                            "properties": {
+                                                                                "provisioningState": {
+                                                                                    "type": "string"
+                                                                                },
+                                                                                "subnet": {
+                                                                                    "properties": {
+                                                                                        "id": {
+                                                                                            "type": "string"
+                                                                                        }
+                                                                                    },
+                                                                                    "type": "object"
+                                                                                }
+                                                                            },
+                                                                            "type": "object"
+                                                                        },
+                                                                        "type": {
+                                                                            "type": "string"
+                                                                        }
+                                                                    },
+                                                                    "required": [
+                                                                        "name",
+                                                                        "id",
+                                                                        "etag",
+                                                                        "properties",
+                                                                        "type"
+                                                                    ],
+                                                                    "type": "object"
+                                                                },
+                                                                "type": "array"
+                                                            },
+                                                            "httpListeners": {
+                                                                "items": {
+                                                                    "properties": {
+                                                                        "etag": {
+                                                                            "type": "string"
+                                                                        },
+                                                                        "id": {
+                                                                            "type": "string"
+                                                                        },
+                                                                        "name": {
+                                                                            "type": "string"
+                                                                        },
+                                                                        "properties": {
+                                                                            "properties": {
+                                                                                "frontendIPConfiguration": {
+                                                                                    "properties": {
+                                                                                        "id": {
+                                                                                            "type": "string"
+                                                                                        }
+                                                                                    },
+                                                                                    "type": "object"
+                                                                                },
+                                                                                "frontendPort": {
+                                                                                    "properties": {
+                                                                                        "id": {
+                                                                                            "type": "string"
+                                                                                        }
+                                                                                    },
+                                                                                    "type": "object"
+                                                                                },
+                                                                                "hostNames": {
+                                                                                    "type": "array"
+                                                                                },
+                                                                                "protocol": {
+                                                                                    "type": "string"
+                                                                                },
+                                                                                "provisioningState": {
+                                                                                    "type": "string"
+                                                                                },
+                                                                                "requestRoutingRules": {
+                                                                                    "items": {
+                                                                                        "properties": {
+                                                                                            "id": {
+                                                                                                "type": "string"
+                                                                                            }
+                                                                                        },
+                                                                                        "required": [
+                                                                                            "id"
+                                                                                        ],
+                                                                                        "type": "object"
+                                                                                    },
+                                                                                    "type": "array"
+                                                                                },
+                                                                                "requireServerNameIndication": {
+                                                                                    "type": "boolean"
+                                                                                }
+                                                                            },
+                                                                            "type": "object"
+                                                                        },
+                                                                        "type": {
+                                                                            "type": "string"
+                                                                        }
+                                                                    },
+                                                                    "required": [
+                                                                        "name",
+                                                                        "id",
+                                                                        "etag",
+                                                                        "properties",
+                                                                        "type"
+                                                                    ],
+                                                                    "type": "object"
+                                                                },
+                                                                "type": "array"
+                                                            },
+                                                            "loadDistributionPolicies": {
+                                                                "type": "array"
+                                                            },
+                                                            "operationalState": {
+                                                                "type": "string"
+                                                            },
+                                                            "privateEndpointConnections": {
+                                                                "type": "array"
+                                                            },
+                                                            "privateLinkConfigurations": {
+                                                                "type": "array"
+                                                            },
+                                                            "probes": {
+                                                                "items": {
+                                                                    "properties": {
+                                                                        "etag": {
+                                                                            "type": "string"
+                                                                        },
+                                                                        "id": {
+                                                                            "type": "string"
+                                                                        },
+                                                                        "name": {
+                                                                            "type": "string"
+                                                                        },
+                                                                        "properties": {
+                                                                            "properties": {
+                                                                                "backendHttpSettings": {
+                                                                                    "items": {
+                                                                                        "properties": {
+                                                                                            "id": {
+                                                                                                "type": "string"
+                                                                                            }
+                                                                                        },
+                                                                                        "required": [
+                                                                                            "id"
+                                                                                        ],
+                                                                                        "type": "object"
+                                                                                    },
+                                                                                    "type": "array"
+                                                                                },
+                                                                                "interval": {
+                                                                                    "type": "integer"
+                                                                                },
+                                                                                "match": {
+                                                                                    "properties": {},
+                                                                                    "type": "object"
+                                                                                },
+                                                                                "minServers": {
+                                                                                    "type": "integer"
+                                                                                },
+                                                                                "path": {
+                                                                                    "type": "string"
+                                                                                },
+                                                                                "pickHostNameFromBackendHttpSettings": {
+                                                                                    "type": "boolean"
+                                                                                },
+                                                                                "protocol": {
+                                                                                    "type": "string"
+                                                                                },
+                                                                                "provisioningState": {
+                                                                                    "type": "string"
+                                                                                },
+                                                                                "timeout": {
+                                                                                    "type": "integer"
+                                                                                },
+                                                                                "unhealthyThreshold": {
+                                                                                    "type": "integer"
+                                                                                }
+                                                                            },
+                                                                            "type": "object"
+                                                                        },
+                                                                        "type": {
+                                                                            "type": "string"
+                                                                        }
+                                                                    },
+                                                                    "required": [
+                                                                        "name",
+                                                                        "id",
+                                                                        "etag",
+                                                                        "properties",
+                                                                        "type"
+                                                                    ],
+                                                                    "type": "object"
+                                                                },
+                                                                "type": "array"
+                                                            },
+                                                            "provisioningState": {
+                                                                "type": "string"
+                                                            },
+                                                            "redirectConfigurations": {
+                                                                "type": "array"
+                                                            },
+                                                            "requestRoutingRules": {
+                                                                "items": {
+                                                                    "properties": {
+                                                                        "etag": {
+                                                                            "type": "string"
+                                                                        },
+                                                                        "id": {
+                                                                            "type": "string"
+                                                                        },
+                                                                        "name": {
+                                                                            "type": "string"
+                                                                        },
+                                                                        "properties": {
+                                                                            "properties": {
+                                                                                "backendAddressPool": {
+                                                                                    "properties": {
+                                                                                        "id": {
+                                                                                            "type": "string"
+                                                                                        }
+                                                                                    },
+                                                                                    "type": "object"
+                                                                                },
+                                                                                "backendHttpSettings": {
+                                                                                    "properties": {
+                                                                                        "id": {
+                                                                                            "type": "string"
+                                                                                        }
+                                                                                    },
+                                                                                    "type": "object"
+                                                                                },
+                                                                                "httpListener": {
+                                                                                    "properties": {
+                                                                                        "id": {
+                                                                                            "type": "string"
+                                                                                        }
+                                                                                    },
+                                                                                    "type": "object"
+                                                                                },
+                                                                                "provisioningState": {
+                                                                                    "type": "string"
+                                                                                },
+                                                                                "rewriteRuleSet": {
+                                                                                    "properties": {
+                                                                                        "id": {
+                                                                                            "type": "string"
+                                                                                        }
+                                                                                    },
+                                                                                    "type": "object"
+                                                                                },
+                                                                                "ruleType": {
+                                                                                    "type": "string"
+                                                                                }
+                                                                            },
+                                                                            "type": "object"
+                                                                        },
+                                                                        "type": {
+                                                                            "type": "string"
+                                                                        }
+                                                                    },
+                                                                    "required": [
+                                                                        "name",
+                                                                        "id",
+                                                                        "etag",
+                                                                        "properties",
+                                                                        "type"
+                                                                    ],
+                                                                    "type": "object"
+                                                                },
+                                                                "type": "array"
+                                                            },
+                                                            "resourceGuid": {
+                                                                "type": "string"
+                                                            },
+                                                            "rewriteRuleSets": {
+                                                                "items": {
+                                                                    "properties": {
+                                                                        "etag": {
+                                                                            "type": "string"
+                                                                        },
+                                                                        "id": {
+                                                                            "type": "string"
+                                                                        },
+                                                                        "name": {
+                                                                            "type": "string"
+                                                                        },
+                                                                        "properties": {
+                                                                            "properties": {
+                                                                                "provisioningState": {
+                                                                                    "type": "string"
+                                                                                },
+                                                                                "requestRoutingRules": {
+                                                                                    "items": {
+                                                                                        "properties": {
+                                                                                            "id": {
+                                                                                                "type": "string"
+                                                                                            }
+                                                                                        },
+                                                                                        "required": [
+                                                                                            "id"
+                                                                                        ],
+                                                                                        "type": "object"
+                                                                                    },
+                                                                                    "type": "array"
+                                                                                },
+                                                                                "rewriteRules": {
+                                                                                    "items": {
+                                                                                        "properties": {
+                                                                                            "actionSet": {
+                                                                                                "properties": {
+                                                                                                    "requestHeaderConfigurations": {
+                                                                                                        "items": {
+                                                                                                            "properties": {
+                                                                                                                "headerName": {
+                                                                                                                    "type": "string"
+                                                                                                                },
+                                                                                                                "headerValue": {
+                                                                                                                    "type": "string"
+                                                                                                                }
+                                                                                                            },
+                                                                                                            "required": [
+                                                                                                                "headerName",
+                                                                                                                "headerValue"
+                                                                                                            ],
+                                                                                                            "type": "object"
+                                                                                                        },
+                                                                                                        "type": "array"
+                                                                                                    },
+                                                                                                    "responseHeaderConfigurations": {
+                                                                                                        "type": "array"
+                                                                                                    }
+                                                                                                },
+                                                                                                "type": "object"
+                                                                                            },
+                                                                                            "conditions": {
+                                                                                                "type": "array"
+                                                                                            },
+                                                                                            "name": {
+                                                                                                "type": "string"
+                                                                                            },
+                                                                                            "ruleSequence": {
+                                                                                                "type": "integer"
+                                                                                            }
+                                                                                        },
+                                                                                        "required": [
+                                                                                            "ruleSequence",
+                                                                                            "conditions",
+                                                                                            "name",
+                                                                                            "actionSet"
+                                                                                        ],
+                                                                                        "type": "object"
+                                                                                    },
+                                                                                    "type": "array"
+                                                                                }
+                                                                            },
+                                                                            "type": "object"
+                                                                        },
+                                                                        "type": {
+                                                                            "type": "string"
+                                                                        }
+                                                                    },
+                                                                    "required": [
+                                                                        "name",
+                                                                        "id",
+                                                                        "etag",
+                                                                        "properties",
+                                                                        "type"
+                                                                    ],
+                                                                    "type": "object"
+                                                                },
+                                                                "type": "array"
+                                                            },
+                                                            "sku": {
+                                                                "properties": {
+                                                                    "capacity": {
+                                                                        "type": "integer"
+                                                                    },
+                                                                    "name": {
+                                                                        "type": "string"
+                                                                    },
+                                                                    "tier": {
+                                                                        "type": "string"
+                                                                    }
+                                                                },
+                                                                "type": "object"
+                                                            },
+                                                            "sslCertificates": {
+                                                                "type": "array"
+                                                            },
+                                                            "sslProfiles": {
+                                                                "type": "array"
+                                                            },
+                                                            "trustedClientCertificates": {
+                                                                "type": "array"
+                                                            },
+                                                            "trustedRootCertificates": {
+                                                                "type": "array"
+                                                            },
+                                                            "urlPathMaps": {
+                                                                "type": "array"
+                                                            },
+                                                            "webApplicationFirewallConfiguration": {
+                                                                "properties": {
+                                                                    "disabledRuleGroups": {
+                                                                        "type": "array"
+                                                                    },
+                                                                    "enabled": {
+                                                                        "type": "boolean"
+                                                                    },
+                                                                    "exclusions": {
+                                                                        "type": "array"
+                                                                    },
+                                                                    "fileUploadLimitInMb": {
+                                                                        "type": "integer"
+                                                                    },
+                                                                    "firewallMode": {
+                                                                        "type": "string"
+                                                                    },
+                                                                    "maxRequestBodySizeInKb": {
+                                                                        "type": "integer"
+                                                                    },
+                                                                    "requestBodyCheck": {
+                                                                        "type": "boolean"
+                                                                    },
+                                                                    "ruleSetType": {
+                                                                        "type": "string"
+                                                                    },
+                                                                    "ruleSetVersion": {
+                                                                        "type": "string"
+                                                                    }
+                                                                },
+                                                                "type": "object"
+                                                            }
+                                                        },
+                                                        "type": "object"
+                                                    },
+                                                    "tags": {
+                                                        "properties": {},
+                                                        "type": "object"
+                                                    },
+                                                    "type": {
+                                                        "type": "string"
+                                                    }
+                                                },
+                                                "type": "object"
+                                            }
+                                        }
+                                    }
+                                }
+                            },
+                            "expression": {
+                                "and": [
+                                    {
+                                        "contains": [
+                                            "@variables('ResourceID2')",
+                                            "profiles"
+                                        ]
+                                    }
+                                ]
+                            },
+                            "type": "If"
+                        },
+                        "Initialize_AttackerIP_variable": {
+                            "runAfter": {
+                                "Initialize_ResourceID2_variable": [
+                                    "Succeeded"
+                                ]
+                            },
+                            "type": "InitializeVariable",
+                            "inputs": {
+                                "variables": [
+                                    {
+                                        "name": "AttackerIP",
+                                        "type": "string",
+                                        "value": "null"
+                                    }
+                                ]
+                            }
+                        },
+                        "Initialize_MatchValue_variable": {
+                            "runAfter": {
+                                "Initialize_Priority_variable": [
+                                    "Succeeded"
+                                ]
+                            },
+                            "type": "InitializeVariable",
+                            "inputs": {
+                                "variables": [
+                                    {
+                                        "name": "MatchValue",
+                                        "type": "array"
+                                    }
+                                ]
+                            }
+                        },
+                        "Initialize_Priority_variable": {
+                            "runAfter": {
+                                "Initialize_Rules_variable": [
+                                    "Succeeded"
+                                ]
+                            },
+                            "type": "InitializeVariable",
+                            "inputs": {
+                                "variables": [
+                                    {
+                                        "name": "Priority",
+                                        "type": "integer",
+                                        "value": 5
+                                    }
+                                ]
+                            }
+                        },
+                        "Initialize_ResourceID1_variable": {
+                            "runAfter": {},
+                            "type": "InitializeVariable",
+                            "inputs": {
+                                "variables": [
+                                    {
+                                        "name": "ResourceID1",
+                                        "type": "string",
+                                        "value": "[parameters('appgatewayID')]"
+                                    }
+                                ]
+                            }
+                        },
+                        "Initialize_ResourceID2_variable": {
+                            "runAfter": {
+                                "Initialize_ResourceID1_variable": [
+                                    "Succeeded"
+                                ]
+                            },
+                            "type": "InitializeVariable",
+                            "inputs": {
+                                "variables": [
+                                    {
+                                        "name": "ResourceID2",
+                                        "type": "string",
+                                        "value": "[parameters('frontdoorID')]"
+                                    }
+                                ]
+                            }
+                        },
+                        "Initialize_Rules_variable": {
+                            "runAfter": {
+                                "Initialize_AttackerIP_variable": [
+                                    "Succeeded"
+                                ]
+                            },
+                            "type": "InitializeVariable",
+                            "inputs": {
+                                "variables": [
+                                    {
+                                        "name": "Rules",
+                                        "type": "array"
+                                    }
+                                ]
+                            }
+                        },
+                        "Parse_Entities": {
+                            "runAfter": {
+                                "Initialize_MatchValue_variable": [
+                                    "Succeeded"
+                                ]
+                            },
+                            "type": "ParseJson",
+                            "inputs": {
+                                "content": "@triggerBody()?['Entities']",
+                                "schema": {
+                                    "items": {
+                                        "properties": {
+                                            "$id": {
+                                                "type": "string"
+                                            },
+                                            "Address": {
+                                                "type": "string"
+                                            },
+                                            "DnsDomain": {
+                                                "type": "string"
+                                            },
+                                            "HostName": {
+                                                "type": "string"
+                                            },
+                                            "Type": {
+                                                "type": "string"
+                                            },
+                                            "Url": {
+                                                "type": "string"
+                                            }
+                                        },
+                                        "required": [
+                                            "$id",
+                                            "Type"
+                                        ],
+                                        "type": "object"
+                                    },
+                                    "type": "array"
+                                }
+                            }
+                        },
+                        "Set_Variables_from_Entities": {
+                            "foreach": "@body('Parse_Entities')",
+                            "actions": {
+                                "Condition": {
+                                    "actions": {
+                                        "Set_variable_2": {
+                                            "runAfter": {},
+                                            "type": "SetVariable",
+                                            "inputs": {
+                                                "name": "ResourceID1",
+                                                "value": "@items('Set_Variables_from_Entities')?['HostName']"
+                                            }
+                                        },
+                                        "Set_variable_3": {
+                                            "runAfter": {
+                                                "Set_variable_2": [
+                                                    "Succeeded"
+                                                ]
+                                            },
+                                            "type": "SetVariable",
+                                            "inputs": {
+                                                "name": "ResourceID2",
+                                                "value": "@items('Set_Variables_from_Entities')?['DnsDomain']"
+                                            }
+                                        }
+                                    },
+                                    "runAfter": {},
+                                    "else": {
+                                        "actions": {
+                                            "Condition_2": {
+                                                "actions": {
+                                                    "Set_variable": {
+                                                        "runAfter": {},
+                                                        "type": "SetVariable",
+                                                        "inputs": {
+                                                            "name": "AttackerIP",
+                                                            "value": "@items('Set_Variables_from_Entities')?['Address']"
+                                                        }
+                                                    }
+                                                },
+                                                "runAfter": {},
+                                                "expression": {
+                                                    "and": [
+                                                        {
+                                                            "equals": [
+                                                                "@items('Set_Variables_from_Entities')['Type']",
+                                                                "ip"
+                                                            ]
+                                                        }
+                                                    ]
+                                                },
+                                                "type": "If"
+                                            }
+                                        }
+                                    },
+                                    "expression": {
+                                        "and": [
+                                            {
+                                                "equals": [
+                                                    "@items('Set_Variables_from_Entities')['Type']",
+                                                    "host"
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    "type": "If"
+                                }
+                            },
+                            "runAfter": {
+                                "Parse_Entities": [
+                                    "Succeeded"
+                                ]
+                            },
+                            "type": "Foreach"
+                        }
+                    },
+                    "outputs": {}
+                },
+                "parameters": {
+                    "$connections": {
+                        "value": {
+                            "azuresentinel": {
+                                "connectionId": "[resourceId('Microsoft.Web/connections', variables('AzureSentinelConnectionName'))]",
+                                "connectionName": "[variables('AzureSentinelConnectionName')]",
+                                "id": "[concat('/subscriptions/', subscription().subscriptionId, '/providers/Microsoft.Web/locations/', resourceGroup().location, '/managedApis/azuresentinel')]"
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    ]
+}


### PR DESCRIPTION
Created and adding a new Playbook for Sentinel Block IP WAF. This new template/playbook now supports AFD standard and Premium WAF policy updates. The old template only supports AFD classic WAF policy updates. 