### PR TITLE
Adding a new Azure Policy for Azure Firewall: VNET with specific Tag must have Azure Firewall deployed

### DIFF
--- a/Azure Firewall/Policy - Azure Policy Definitions/Policy - VNET with specific Tag must have Azure Firewall deployed/README.md
+++ b/Azure Firewall/Policy - Azure Policy Definitions/Policy - VNET with specific Tag must have Azure Firewall deployed/README.md
@@ -1,0 +1,17 @@
+# VNET with specific Tag must have Azure Firewall deployed - JSON
+
+This is the Azure Policy Definition script to find all VNETS with specific Tag and check if ther is an Azure Firewall deployed and flag as non-compliant if no Azure Firewall exists.
+
+## Contributing
+
+This project welcomes contributions and suggestions.  Most contributions require you to agree to a
+Contributor License Agreement (CLA) declaring that you have the right to, and actually do, grant us
+the rights to use your contribution. For details, visit https://cla.opensource.microsoft.com.
+
+When you submit a pull request, a CLA bot will automatically determine whether you need to provide
+a CLA and decorate the PR appropriately (e.g., status check, comment). Simply follow the instructions
+provided by the bot. You will only need to do this once across all repos using our CLA.
+
+This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/).
+For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or
+contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.

--- a/Azure Firewall/Policy - Azure Policy Definitions/Policy - VNET with specific Tag must have Azure Firewall deployed/VNET with specific Tag must have Azure Firewall deployed.json
+++ b/Azure Firewall/Policy - Azure Policy Definitions/Policy - VNET with specific Tag must have Azure Firewall deployed/VNET with specific Tag must have Azure Firewall deployed.json
@@ -1,0 +1,90 @@
+{
+    "mode": "All",
+    "policyRule": {
+      "if": {
+        "allOf": [
+          {
+            "field": "type",
+            "equals": "Microsoft.Network/virtualNetworks"
+          },
+          {
+            "field": "[concat('tags[', parameters('tagName'), ']')]",
+            "equals": "[parameters('tagValue')]"
+          },
+          {
+            "anyOf": [
+              {
+                "allOf": [
+                  {
+                    "count": {
+                      "field": "Microsoft.Network/virtualNetworks/subnets[*]",
+                      "where": {
+                        "allOf": [
+                          {
+                            "field": "Microsoft.Network/virtualNetworks/subnets[*].name",
+                            "equals": "AzureFirewallSubnet"
+                          },
+                          {
+                            "field": "Microsoft.Network/virtualNetworks/subnets[*].ipConfigurations[*].id",
+                            "exists": false
+                          }
+                        ]
+                      }
+                    },
+                    "greaterOrEquals": 1
+                  }
+                ]
+              },
+              {
+                "count": {
+                  "field": "Microsoft.Network/virtualNetworks/subnets[*]",
+                  "where": {
+                    "allOf": [
+                      {
+                        "field": "Microsoft.Network/virtualNetworks/subnets[*].name",
+                        "equals": "AzureFirewallSubnet"
+                      }
+                    ]
+                  }
+                },
+                "equals": 0
+              }
+            ]
+          }
+        ]
+      },
+      "then": {
+        "effect": "[parameters('effect')]"
+      }
+    },
+    "parameters": {
+      "effect": {
+        "type": "String",
+        "metadata": {
+          "displayName": "Effect",
+          "description": "Enable or disable the execution of the policy"
+        },
+        "allowedValues": [
+          "Audit",
+          "Disabled"
+        ],
+        "defaultValue": "Audit"
+      },
+      "tagName": {
+        "type": "String",
+        "metadata": {
+          "displayName": "Tag Name",
+          "description": "Name of the tag, such as 'Firewall Required'"
+        },
+        "defaultValue": "Firewall Required"
+      },
+      "tagValue": {
+        "type": "String",
+        "metadata": {
+          "displayName": "Tag Value",
+          "description": "Value of the tag, such as 'Yes'"
+        },
+        "defaultValue": "Yes"
+      }
+    }
+  }


### PR DESCRIPTION
Creating PR for uploading the new Azure Policy for Azure Firewall which will check VNETS with specific Tag to check if there is an Azure Firewall deployed and mark it as non-compliant in case no Azure Firewall is deployed.