### PR TITLE
Create Query - AZFW Ruleset Change Tracking

### DIFF
--- a/Azure Firewall/Alerts - Queries and Alerts/Query - AZFW Ruleset Change Tracking
+++ b/Azure Firewall/Alerts - Queries and Alerts/Query - AZFW Ruleset Change Tracking
@@ -1,0 +1,101 @@
+networkresourcechanges
+
+| where properties contains "microsoft.network/firewallpolicies/rulecollectiongroups"
+
+| extend parsedProperties = parse_json(properties)
+
+| extend TargetResource = tostring(parsedProperties.targetResourceId),
+
+         Timestamp = todatetime(parsedProperties.changeAttributes.timestamp),
+
+         Changes = todynamic(parsedProperties.changes),
+
+         ChangeType = tostring(parsedProperties.changeType),
+
+         PreviousSnapshotId = tostring(parsedProperties.changeAttributes.previousResourceSnapshotId),
+
+         NewSnapshotId = tostring(parsedProperties.changeAttributes.newResourceSnapshotId),
+
+         CorrelationId = tostring(parsedProperties.changeAttributes.correlationId),
+
+         ChangesCount = toint(parsedProperties.changeAttributes.changesCount),
+
+         TenantId = tostring(tenantId),
+
+         Location = tostring(location),
+
+         SubscriptionId = tostring(subscriptionId),
+
+         ResourceGroup = tostring(resourceGroup),
+
+         FirewallPolicyName = extract('/firewallPolicies/([^/]+)/', 1, tostring(id))
+
+| mv-expand ChangeKey = bag_keys(Changes)
+
+| extend ChangeDetails = todynamic(Changes[tostring(ChangeKey)])
+
+| extend RuleCollectionName = extract('properties\\.ruleCollections\\["([^"]+)"\\]', 1, tostring(ChangeKey))
+
+| where isnotempty(RuleCollectionName)
+
+| summarize
+
+    Changes = make_list(pack("ChangeKey", ChangeKey, "PreviousValue", tostring(ChangeDetails.previousValue), "NewValue", tostring(ChangeDetails.newValue)))
+
+    by
+
+    Timestamp = format_datetime(Timestamp, 'yyyy-MM-dd HH:mm:ss'),
+
+    TenantId,
+
+    SubscriptionId,
+
+    ResourceGroup,
+
+    Location,
+
+    TargetResource,
+
+    FirewallPolicyName,
+
+    RuleCollectionName,
+
+    ChangeType,
+
+    PreviousSnapshotId,
+
+    NewSnapshotId,
+
+    CorrelationId,
+
+    ChangesCount
+
+| project
+
+    Timestamp,
+
+    TenantId,
+
+    SubscriptionId,
+
+    ResourceGroup,
+
+    Location,
+
+    TargetResource,
+
+    FirewallPolicyName,
+
+    RuleCollectionName,
+
+    ChangeType,
+
+    PreviousSnapshotId,
+
+    NewSnapshotId,
+
+    CorrelationId,
+
+    ChangesCount,
+
+    Changes


### PR DESCRIPTION
This enhanced query filters changes related to Azure Firewall's Rule Collection Groups, parses and extracts key details like timestamps, change types, and rule collection names, and formats the output for readability. This provides a clear and detailed log of configuration changes, making it easier for administrators to monitor and analyze changes over time.