### PR TITLE
Add README for Azure Policy - Enable Geo Block Rules

### DIFF
--- a/Azure WAF/Policy - Azure Policy Definitions/Policy - Enable Geo Block Rules/README.md
+++ b/Azure WAF/Policy - Azure Policy Definitions/Policy - Enable Geo Block Rules/README.md
@@ -1,0 +1,16 @@
+# Azure Policy - Enagle Geo Block Rules
+
+## Description
+This policy identifies Web Application Firewall (WAF) configurations that lack a Geo-Block rule, which may indicate that inbound traffic from all locations is being permitted unnecessarily.
+
+## Parameters
+- **effect**: The effect of the policy (audit)
+
+## Scope
+This policy applies to:
+- Application Gateway WAF V2
+
+## Compliance
+This policy helps ensure:
+- Security compliance by maintaining clean WAF configurations
+- Proper utilization of Azure Application Gateway WAF V2


### PR DESCRIPTION
This README provides an overview of the Azure Policy for enabling Geo Block rules in WAF configurations, including its purpose, parameters, scope, and compliance benefits.